### PR TITLE
fix: fix security issue in hono.ts

### DIFF
--- a/packages/web/src/server/hono.ts
+++ b/packages/web/src/server/hono.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from "node:crypto";
 import { Readable } from "node:stream";
 import busboy from "busboy";
 import { Hono } from "hono";
+import { bearerAuth } from "hono/bearer-auth";
 import {
   type ExtractionEvent,
   extractData,
@@ -10,7 +12,14 @@ import {
 } from "./api";
 import { fetchConfig, fetchModels } from "./models";
 
+// Shared secret required to access the API. Set STRUKTUR_SERVER_TOKEN so trusted
+// clients (e.g. the desktop shell) can authenticate; otherwise a random per-process
+// token is generated so the server never starts up unauthenticated.
+export const SERVER_TOKEN = process.env.STRUKTUR_SERVER_TOKEN ?? randomUUID();
+
 export const app = new Hono();
+
+app.use("/api/*", bearerAuth({ token: SERVER_TOKEN }));
 
 app.post("/api/parse", async (c) => {
   const contentType = c.req.header("content-type");


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `packages/web/src/server/hono.ts`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `packages/web/src/server/hono.ts:15` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: All API endpoints in the Hono server are exposed without any authentication mechanism. Any user with network access to the server can invoke data extraction, parsing, and configuration endpoints without providing credentials.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `packages/web/src/server/hono.ts`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

## Security Invariant
> **Property**: Protected endpoints reject unauthenticated requests

<details>
<summary>Regression test</summary>

```typescript
import { describe, test, expect } from "vitest";
import app from "./packages/web/src/server/hono";

describe("protected endpoints reject unauthenticated requests", () => {
  const testCases = [
    { name: "missing_token", headers: {} },
    { name: "malformed_token", headers: { Authorization: "Bearer invalid" } },
    { name: "empty_token", headers: { Authorization: "Bearer " } },
  ];

  const protectedEndpoints = [
    { method: "POST", path: "/api/parse", body: { url: "https://example.com" } },
    { method: "GET", path: "/api/config" },
  ];

  test.each(testCases)("rejects request with $name", async ({ headers }) => {
    for (const endpoint of protectedEndpoints) {
      const res = await app.request(endpoint.path, {
        method: endpoint.method,
        headers: { "Content-Type": "application/json", ...headers },
        body: endpoint.body ? JSON.stringify(endpoint.body) : undefined,
      });
      expect([401, 403]).toContain(res.status);
    }
  });
});
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-002 scanner=multi_agent_ai -->
